### PR TITLE
feat(infra): Docker Compose service mesh for containerized pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+__pycache__
+*.pyc
+.venv
+.env
+.env.local
+.pytest_cache
+.mypy_cache
+.ruff_cache
+data/audio/segment_*
+*.egg-info
+.claude/

--- a/.env.example
+++ b/.env.example
@@ -52,3 +52,26 @@ ASSETS_DIR=data/assets
 
 # Generated audio files directory
 AUDIO_OUTPUT_DIR=data/audio
+
+# ============================================================================
+# DOCKER INFRASTRUCTURE (used by docker-compose services)
+# ============================================================================
+# Cloudflare R2 Storage
+R2_ACCOUNT_ID=
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+R2_BUCKET_NAME=kids-curiosity-club
+
+# CDN
+CDN_BASE_URL=https://cdn.kidscuriosityclub.com
+
+# LLM Service (Docker)
+LLM_MODEL=gemma4:26b-a4b
+LLM_BASE_URL=http://llm:11434/v1
+
+# TTS Service (Docker)
+TTS_MODEL=vibevoice-1.5b
+TTS_BASE_URL=http://tts:8100
+
+# Distribution Service (Docker)
+DISTRIBUTION_BASE_URL=http://distribution:8200

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+.PHONY: up down up-gpu up-dev logs health pull-models clean
+
+up:
+	docker compose up -d distribution app
+
+up-gpu:
+	docker compose --profile gpu up -d
+
+up-dev:
+	docker compose --profile gpu --profile dev up -d
+
+down:
+	docker compose down
+
+logs:
+	docker compose logs -f
+
+health:
+	@echo "=== Service Health ==="
+	@curl -sf http://localhost:8000/api/health 2>/dev/null && echo "app: OK" || echo "app: DOWN"
+	@curl -sf http://localhost:8200/health 2>/dev/null && echo "distribution: OK" || echo "distribution: DOWN"
+	@curl -sf http://localhost:8100/health 2>/dev/null && echo "tts: OK" || echo "tts: DOWN"
+	@curl -sf http://localhost:11434/api/tags 2>/dev/null && echo "llm: OK" || echo "llm: DOWN"
+	@curl -sf http://localhost:3000/ 2>/dev/null && echo "frontend: OK" || echo "frontend: DOWN"
+
+pull-models:
+	docker compose exec llm ollama pull gemma4:26b-a4b
+
+clean:
+	docker compose down -v --rmi local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,89 @@
+services:
+  llm:
+    image: ollama/ollama:latest
+    ports: ["11434:11434"]
+    volumes:
+      - ollama-models:/root/.ollama
+      - episode-data:/data
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:11434/api/tags"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+    profiles: ["gpu"]
+    networks: [podcast-net]
+
+  tts:
+    build: ./docker/tts
+    ports: ["8100:8100"]
+    volumes:
+      - tts-models:/app/models
+      - episode-data:/data
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8100/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 120s
+    profiles: ["gpu"]
+    networks: [podcast-net]
+
+  distribution:
+    build: ./docker/distribution
+    ports: ["8200:8200"]
+    volumes:
+      - episode-data:/data
+    env_file: .env
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8200/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+    networks: [podcast-net]
+
+  app:
+    build: ./docker/app
+    ports: ["8000:8000"]
+    volumes:
+      - episode-data:/data
+    env_file: .env
+    depends_on:
+      distribution:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8000/api/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+    networks: [podcast-net]
+
+  frontend:
+    build: ./docker/frontend
+    ports: ["3000:80"]
+    depends_on: [app]
+    profiles: ["dev"]
+    networks: [podcast-net]
+
+networks:
+  podcast-net:
+    driver: bridge
+
+volumes:
+  ollama-models:
+  tts-models:
+  episode-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,11 @@
+name: kids-podcast
+
 services:
   llm:
-    image: ollama/ollama:latest
-    ports: ["11434:11434"]
+    build:
+      context: .
+      dockerfile: docker/llm/Dockerfile
+    ports: ["127.0.0.1:11434:11434"]
     volumes:
       - ollama-models:/root/.ollama
       - episode-data:/data
@@ -18,12 +22,15 @@ services:
       timeout: 10s
       retries: 5
       start_period: 60s
+    restart: unless-stopped
     profiles: ["gpu"]
     networks: [podcast-net]
 
   tts:
-    build: ./docker/tts
-    ports: ["8100:8100"]
+    build:
+      context: .
+      dockerfile: docker/tts/Dockerfile
+    ports: ["127.0.0.1:8100:8100"]
     volumes:
       - tts-models:/app/models
       - episode-data:/data
@@ -40,11 +47,14 @@ services:
       timeout: 10s
       retries: 5
       start_period: 120s
+    restart: unless-stopped
     profiles: ["gpu"]
     networks: [podcast-net]
 
   distribution:
-    build: ./docker/distribution
+    build:
+      context: .
+      dockerfile: docker/distribution/Dockerfile
     ports: ["8200:8200"]
     volumes:
       - episode-data:/data
@@ -54,10 +64,13 @@ services:
       interval: 15s
       timeout: 5s
       retries: 3
+    restart: unless-stopped
     networks: [podcast-net]
 
   app:
-    build: ./docker/app
+    build:
+      context: .
+      dockerfile: docker/app/Dockerfile
     ports: ["8000:8000"]
     volumes:
       - episode-data:/data
@@ -70,12 +83,21 @@ services:
       interval: 15s
       timeout: 5s
       retries: 3
+    restart: unless-stopped
     networks: [podcast-net]
 
   frontend:
-    build: ./docker/frontend
+    build:
+      context: .
+      dockerfile: docker/frontend/Dockerfile
     ports: ["3000:80"]
     depends_on: [app]
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:80/"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
     profiles: ["dev"]
     networks: [podcast-net]
 

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY pyproject.toml .
+COPY src/ ./src/
+COPY data/ ./data/
+RUN pip install --no-cache-dir .
+EXPOSE 8000
+CMD ["uvicorn", "src.api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,8 +1,21 @@
 FROM python:3.12-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl ffmpeg && \
+    rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
+
+# Install dependencies first for layer caching
 COPY pyproject.toml .
-COPY src/ ./src/
-COPY data/ ./data/
 RUN pip install --no-cache-dir .
+
+# Copy source code
+COPY src/ ./src/
+
+ENV PYTHONPATH=/app/src
 EXPOSE 8000
-CMD ["uvicorn", "src.api.main:app", "--host", "0.0.0.0", "--port", "8000"]
+
+HEALTHCHECK --interval=15s --timeout=5s --retries=3 \
+    CMD curl -sf http://localhost:8000/api/health || exit 1
+
+CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker/distribution/Dockerfile
+++ b/docker/distribution/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+RUN pip install --no-cache-dir fastapi uvicorn[standard] feedgen boto3 mutagen pydantic pydantic-settings
+COPY server.py /app/server.py
+WORKDIR /app
+EXPOSE 8200
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8200"]

--- a/docker/distribution/server.py
+++ b/docker/distribution/server.py
@@ -1,0 +1,11 @@
+"""Placeholder distribution service for Docker Compose infrastructure."""
+
+from fastapi import FastAPI
+
+app = FastAPI(title="Distribution Service", version="0.1.0")
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    """Health check endpoint."""
+    return {"status": "ok", "service": "distribution"}

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -1,0 +1,4 @@
+FROM nginx:alpine
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY website/ /usr/share/nginx/html/
+EXPOSE 80

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -1,4 +1,4 @@
 FROM nginx:alpine
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY docker/frontend/nginx.conf /etc/nginx/conf.d/default.conf
 COPY website/ /usr/share/nginx/html/
 EXPOSE 80

--- a/docker/frontend/nginx.conf
+++ b/docker/frontend/nginx.conf
@@ -1,0 +1,48 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Serve static files
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Reverse proxy: API
+    location /api/ {
+        proxy_pass http://app:8000/api/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Reverse proxy: LLM (Ollama)
+    location /llm/ {
+        proxy_pass http://llm:11434/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Reverse proxy: TTS
+    location /tts/ {
+        proxy_pass http://tts:8100/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Reverse proxy: Distribution
+    location /dist/ {
+        proxy_pass http://distribution:8200/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/docker/llm/Dockerfile
+++ b/docker/llm/Dockerfile
@@ -1,0 +1,6 @@
+FROM ollama/ollama:latest
+COPY docker/llm/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENV LLM_MODEL=gemma4:26b-a4b
+EXPOSE 11434
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/llm/entrypoint.sh
+++ b/docker/llm/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+ollama serve &
+sleep 5
+if ! ollama list | grep -q "gemma4"; then
+    echo "Pulling Gemma 4 model..."
+    ollama pull gemma4:26b-a4b
+fi
+wait

--- a/docker/tts/Dockerfile
+++ b/docker/tts/Dockerfile
@@ -1,0 +1,6 @@
+FROM pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime
+RUN pip install --no-cache-dir fastapi uvicorn[standard] python-multipart
+COPY server.py /app/server.py
+WORKDIR /app
+EXPOSE 8100
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8100"]

--- a/docker/tts/server.py
+++ b/docker/tts/server.py
@@ -1,0 +1,11 @@
+"""Placeholder TTS service for Docker Compose infrastructure."""
+
+from fastapi import FastAPI
+
+app = FastAPI(title="TTS Service", version="0.1.0")
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    """Health check endpoint."""
+    return {"status": "ok", "service": "tts", "model": "vibevoice-1.5b"}


### PR DESCRIPTION
## Summary

Closes #87

- Add `docker-compose.yml` with 5 services: `llm` (Ollama/GPU), `tts` (PyTorch/GPU), `distribution`, `app`, and `frontend` (nginx), connected via `podcast-net` bridge network with shared `episode-data` volume
- Create stub Dockerfiles and placeholder FastAPI servers for TTS and distribution services
- Add nginx reverse proxy config routing `/api/`, `/llm/`, `/tts/`, `/dist/` to backend services
- Add `Makefile` with targets: `up`, `up-gpu`, `up-dev`, `down`, `logs`, `health`, `pull-models`, `clean`
- Add `.dockerignore` and extend `.env.example` with Docker service URLs (R2, CDN, LLM, TTS, distribution)
- Add `docker/llm/entrypoint.sh` to auto-pull Gemma 4 model on first start

### Architecture

```
                    :3000
                 +---------+
                 | frontend |  (nginx)
                 +----+----+
                      |
       +--------------+--------------+-----------+
       |              |              |           |
  /api/          /llm/          /tts/       /dist/
       |              |              |           |
  +----+----+   +-----+-----+  +----+----+ +----+------+
  |   app   |   |    llm    |  |   tts   | |distribution|
  | :8000   |   |  :11434   |  | :8100   | |  :8200     |
  +---------+   +-----------+  +---------+ +------------+
       |              |              |           |
       +--------------+--------------+-----------+
                      |
               [episode-data]  (shared volume)
```

### Files created

| File | Purpose |
|------|---------|
| `docker-compose.yml` | Service definitions, networks, volumes |
| `docker/llm/entrypoint.sh` | Ollama startup + model pull |
| `docker/tts/Dockerfile` | PyTorch CUDA base image |
| `docker/tts/server.py` | Placeholder TTS FastAPI server |
| `docker/distribution/Dockerfile` | Python slim base image |
| `docker/distribution/server.py` | Placeholder distribution FastAPI server |
| `docker/app/Dockerfile` | Main app container |
| `docker/frontend/Dockerfile` | Nginx static + reverse proxy |
| `docker/frontend/nginx.conf` | Reverse proxy routing config |
| `Makefile` | Convenience targets for compose operations |
| `.dockerignore` | Exclude build artifacts from Docker context |
| `.env.example` | Updated with Docker infrastructure vars |

## Test plan

- [ ] Verify `docker compose config` validates the compose file (requires Docker)
- [ ] Verify `make health` target runs without errors
- [ ] Verify nginx.conf proxies all routes correctly
- [ ] Verify placeholder servers return valid health responses
- [ ] Verify GPU services only start with `--profile gpu`

Generated with [Claude Code](https://claude.com/claude-code)