### PR TITLE
fix(admin): improve episode page script/section readability

### DIFF
--- a/website/admin/episode.html
+++ b/website/admin/episode.html
@@ -115,22 +115,32 @@
             font-weight: 700; margin-right: 0.75rem;
         }
 
-        .beat-title { font-weight: 600; font-size: 1rem; }
-        .beat-description { color: #374151; margin: 0.75rem 0; font-size: 0.9rem; line-height: 1.6; }
+        .beat-title { font-weight: 600; font-size: 1.05rem; color: #111827; }
+        .beat-description { color: #1f2937; margin: 0.75rem 0; font-size: 1rem; line-height: 1.65; }
 
         /* Script blocks */
         .script-block {
-            padding: 0.75rem 1rem; border-bottom: 1px solid #f3f4f6;
+            padding: 1rem 1.25rem;
+            border-bottom: 1px solid #e5e7eb;
+            background: #f9fafb;
         }
 
+        .script-block:nth-child(even) { background: #f3f4f6; }
         .script-block:last-child { border-bottom: none; }
 
         .speaker-name {
-            font-weight: 600; font-size: 0.85rem;
-            color: #3b82f6; text-transform: uppercase; letter-spacing: 0.03em;
+            display: inline-block;
+            font-weight: 600; font-size: 0.8rem;
+            color: #1d4ed8; background: #dbeafe;
+            text-transform: uppercase; letter-spacing: 0.04em;
+            padding: 0.15rem 0.6rem; border-radius: 999px;
+            margin-bottom: 0.5rem;
         }
 
-        .script-text { font-size: 0.9rem; color: #374151; margin-top: 0.25rem; line-height: 1.5; }
+        .script-text {
+            font-size: 1.05rem; color: #1f2937;
+            margin-top: 0.25rem; line-height: 1.65;
+        }
 
         /* Metadata */
         .meta-card { text-align: center; }


### PR DESCRIPTION
## Summary

- Bumps generated script & section text from 0.9rem → 1.0–1.05rem and darkens body color to `#1f2937` for stronger contrast.
- Tints script blocks with an alternating `#f9fafb`/`#f3f4f6` background and strengthens the divider for easier scanning.
- Styles speaker names as a pill (colored background + padding + rounded) so each line is visually anchored.

Closes #99

## Test plan

- [ ] Open `website/admin/episode.html?id=<existing-episode>` — confirm script dialogue is comfortably readable at ~60 cm viewing distance.
- [ ] Verify speaker pills render correctly and alternate block backgrounds don't clash with Bootstrap's accordion.
- [ ] Narrow viewport (~375 px) — confirm no layout regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)