### PR TITLE
feat(llm): default to Claude Haiku 4.5 with prompt caching support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,8 +26,14 @@ USE_MOCK_SERVICES=true
 # ============================================================================
 # PROVIDER PREFERENCES
 # ============================================================================
-# Which LLM provider to use (openai, anthropic, gemini, mock)
-LLM_PROVIDER=openai
+# Which LLM provider to use (anthropic, openai, gemini, mock)
+# Default is anthropic (Claude Haiku 4.5) — strong for narrative kids' content
+# and supports prompt caching on repeated show/protagonist/world prompts.
+LLM_PROVIDER=anthropic
+
+# Override the Anthropic model (optional). Defaults to claude-haiku-4-5-20251001.
+# Other options: claude-sonnet-4-6, claude-opus-4-7
+# ANTHROPIC_MODEL=claude-haiku-4-5-20251001
 
 # Which text-to-speech provider to use (elevenlabs, google, openai, mock)
 TTS_PROVIDER=elevenlabs

--- a/src/config.py
+++ b/src/config.py
@@ -27,7 +27,7 @@ class Settings(BaseSettings):
     ELEVENLABS_API_KEY: str | None = None
 
     # Provider selection
-    LLM_PROVIDER: str = "openai"  # openai, anthropic, gemini, mock
+    LLM_PROVIDER: str = "anthropic"  # anthropic, openai, gemini, mock
     TTS_PROVIDER: str = "elevenlabs"  # elevenlabs, google, openai, mock
     IMAGE_PROVIDER: str = "flux"  # flux, dalle, mock
 

--- a/src/services/llm/anthropic_provider.py
+++ b/src/services/llm/anthropic_provider.py
@@ -12,16 +12,31 @@ from tenacity import (
 
 from services.llm.base import BaseLLMProvider
 
+DEFAULT_MODEL = "claude-haiku-4-5-20251001"
+
+
+def _build_system_param(system: str | None) -> list[dict[str, Any]] | None:
+    """Wrap a system prompt for ephemeral prompt caching."""
+    if not system:
+        return None
+    return [
+        {
+            "type": "text",
+            "text": system,
+            "cache_control": {"type": "ephemeral"},
+        }
+    ]
+
 
 class AnthropicProvider(BaseLLMProvider):
     """Anthropic Claude LLM provider with retry logic."""
 
-    def __init__(self, api_key: str, model: str = "claude-3-sonnet-20240229") -> None:
+    def __init__(self, api_key: str, model: str = DEFAULT_MODEL) -> None:
         """Initialize Anthropic provider.
 
         Args:
             api_key: Anthropic API key
-            model: Model to use for generation
+            model: Model to use for generation (defaults to Claude Haiku 4.5)
         """
         try:
             from anthropic import AsyncAnthropic
@@ -44,14 +59,19 @@ class AnthropicProvider(BaseLLMProvider):
         prompt: str,
         max_tokens: int = 2000,
         temperature: float = 0.7,
+        system: str | None = None,
         **kwargs: Any,
     ) -> str:
         """Generate text from prompt with retry logic.
 
         Args:
-            prompt: The input prompt for the LLM
+            prompt: The user prompt for the LLM
             max_tokens: Maximum number of tokens to generate
             temperature: Sampling temperature
+            system: Optional system prompt. When provided, it is sent with
+                ephemeral ``cache_control`` so repeated calls with the same
+                system prompt (e.g. show/protagonist/world) can hit the
+                prompt cache.
             **kwargs: Additional Anthropic parameters
 
         Returns:
@@ -60,13 +80,18 @@ class AnthropicProvider(BaseLLMProvider):
         Raises:
             Exception: If generation fails after retries
         """
-        response = await self.client.messages.create(
-            model=self.model,
-            max_tokens=max_tokens,
-            temperature=temperature,
-            messages=[{"role": "user", "content": prompt}],
+        create_kwargs: dict[str, Any] = {
+            "model": self.model,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "messages": [{"role": "user", "content": prompt}],
             **kwargs,
-        )
+        }
+        system_param = _build_system_param(system)
+        if system_param is not None:
+            create_kwargs["system"] = system_param
+
+        response = await self.client.messages.create(**create_kwargs)
 
         # Extract text from response
         if response.content and len(response.content) > 0:
@@ -78,26 +103,33 @@ class AnthropicProvider(BaseLLMProvider):
         prompt: str,
         max_tokens: int = 2000,
         temperature: float = 0.7,
+        system: str | None = None,
         **kwargs: Any,
     ) -> AsyncGenerator[str, None]:
         """Generate text with streaming support.
 
         Args:
-            prompt: The input prompt for the LLM
+            prompt: The user prompt for the LLM
             max_tokens: Maximum number of tokens to generate
             temperature: Sampling temperature
+            system: Optional system prompt (see ``generate``)
             **kwargs: Additional Anthropic parameters
 
         Yields:
             Text chunks as they are generated
         """
-        async with self.client.messages.stream(
-            model=self.model,
-            max_tokens=max_tokens,
-            temperature=temperature,
-            messages=[{"role": "user", "content": prompt}],
+        stream_kwargs: dict[str, Any] = {
+            "model": self.model,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "messages": [{"role": "user", "content": prompt}],
             **kwargs,
-        ) as stream:
+        }
+        system_param = _build_system_param(system)
+        if system_param is not None:
+            stream_kwargs["system"] = system_param
+
+        async with self.client.messages.stream(**stream_kwargs) as stream:
             async for text in stream.text_stream:
                 yield text
 
@@ -129,20 +161,29 @@ class AnthropicProvider(BaseLLMProvider):
             Cost in USD
 
         Note:
-            Pricing as of 2024:
-            - Claude 3 Opus: $0.015/1K input, $0.075/1K output
-            - Claude 3 Sonnet: $0.003/1K input, $0.015/1K output
-            - Claude 3 Haiku: $0.00025/1K input, $0.00125/1K output
+            Pricing tiers (per 1M tokens, approximate — confirm against
+            https://anthropic.com/pricing):
+            - Opus 4.x:   $15 input / $75 output
+            - Sonnet 4.x: $3 input  / $15 output
+            - Haiku 4.5:  $1 input  / $5 output
+            - Haiku 3.5:  $0.80 input / $4 output
+            - Claude 3 Haiku: $0.25 input / $1.25 output
         """
-        # Determine pricing based on model
-        if "opus" in self.model.lower():
-            input_cost = input_tokens * 0.015 / 1000
-            output_cost = output_tokens * 0.075 / 1000
-        elif "haiku" in self.model.lower():
-            input_cost = input_tokens * 0.00025 / 1000
-            output_cost = output_tokens * 0.00125 / 1000
-        else:  # Sonnet (default)
-            input_cost = input_tokens * 0.003 / 1000
-            output_cost = output_tokens * 0.015 / 1000
+        model_lower = self.model.lower()
+        if "opus" in model_lower:
+            input_cost = input_tokens * 15.0 / 1_000_000
+            output_cost = output_tokens * 75.0 / 1_000_000
+        elif "haiku-4" in model_lower:
+            input_cost = input_tokens * 1.0 / 1_000_000
+            output_cost = output_tokens * 5.0 / 1_000_000
+        elif "haiku-3-5" in model_lower or "haiku-3.5" in model_lower:
+            input_cost = input_tokens * 0.80 / 1_000_000
+            output_cost = output_tokens * 4.0 / 1_000_000
+        elif "haiku" in model_lower:
+            input_cost = input_tokens * 0.25 / 1_000_000
+            output_cost = output_tokens * 1.25 / 1_000_000
+        else:  # Sonnet (default for unknown Claude models)
+            input_cost = input_tokens * 3.0 / 1_000_000
+            output_cost = output_tokens * 15.0 / 1_000_000
 
         return input_cost + output_cost

--- a/src/services/llm/factory.py
+++ b/src/services/llm/factory.py
@@ -1,5 +1,6 @@
 """Factory for creating LLM provider instances."""
 
+import os
 from pathlib import Path
 
 from services.llm.anthropic_provider import AnthropicProvider
@@ -49,8 +50,9 @@ class LLMProviderFactory:
         elif provider_type == "anthropic":
             if not api_key:
                 raise ValueError("API key is required for Anthropic provider")
-            if model:
-                provider = AnthropicProvider(api_key=api_key, model=model)
+            resolved_model = model or os.getenv("ANTHROPIC_MODEL")
+            if resolved_model:
+                provider = AnthropicProvider(api_key=api_key, model=resolved_model)
             else:
                 provider = AnthropicProvider(api_key=api_key)
 

--- a/tests/services/llm/test_providers.py
+++ b/tests/services/llm/test_providers.py
@@ -132,9 +132,31 @@ class TestLLMProviderFactory:
                 "anthropic", api_key="test-key-123"
             )
             assert isinstance(provider, BaseLLMProvider)
-            assert provider.model == "claude-3-sonnet-20240229"
+            assert provider.model == "claude-haiku-4-5-20251001"
         except ImportError as e:
             # Skip test if anthropic package not installed
+            pytest.skip(f"Anthropic package not installed: {e}")
+
+    def test_create_anthropic_provider_custom_model(self):
+        """Test creating Anthropic provider with custom model."""
+        try:
+            provider = LLMProviderFactory.create_provider(
+                "anthropic", api_key="test-key-123", model="claude-sonnet-4-6"
+            )
+            assert isinstance(provider, BaseLLMProvider)
+            assert provider.model == "claude-sonnet-4-6"
+        except ImportError as e:
+            pytest.skip(f"Anthropic package not installed: {e}")
+
+    def test_create_anthropic_provider_env_override(self, monkeypatch):
+        """Test ANTHROPIC_MODEL env var overrides the default."""
+        monkeypatch.setenv("ANTHROPIC_MODEL", "claude-opus-4-7")
+        try:
+            provider = LLMProviderFactory.create_provider(
+                "anthropic", api_key="test-key-123"
+            )
+            assert provider.model == "claude-opus-4-7"
+        except ImportError as e:
             pytest.skip(f"Anthropic package not installed: {e}")
 
     def test_create_gemini_provider_without_key(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -186,15 +186,15 @@ class TestSettingsValidation:
     def test_case_sensitivity(self, monkeypatch):
         """Test that environment variables are case-sensitive."""
         monkeypatch.setenv("USE_MOCK_SERVICES", "true")
-        monkeypatch.setenv("llm_provider", "anthropic")  # lowercase
+        monkeypatch.setenv("llm_provider", "openai")  # lowercase, ignored
 
         settings = Settings()
-        # Should use default, not the lowercase version
-        assert settings.LLM_PROVIDER == "openai"
+        # Should use default (anthropic), not the lowercase version
+        assert settings.LLM_PROVIDER == "anthropic"
 
         # Reset and test with correct case
         reset_settings()
 
-        monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+        monkeypatch.setenv("LLM_PROVIDER", "openai")
         settings = Settings()
-        assert settings.LLM_PROVIDER == "anthropic"
+        assert settings.LLM_PROVIDER == "openai"


### PR DESCRIPTION
## Summary

- Switch default LLM from OpenAI `gpt-4o-mini` to Anthropic **Claude Haiku 4.5** (`claude-haiku-4-5-20251001`) — newer cheap-tier model, better fit for the narrative, tone-sensitive writing this project generates.
- `AnthropicProvider.generate()` and `generate_stream()` now accept an optional `system` prompt; when provided it is sent as a system block with **ephemeral `cache_control`** so repeated show/protagonist/world prompts hit Anthropic's prompt cache. Services are free to start passing `system=...` incrementally.
- Cost table refreshed for Claude 4.x tiers (Haiku 4.5 $1/$5 per M, Sonnet 4.x $3/$15, Opus 4.x $15/$75).
- `ANTHROPIC_MODEL` env var can override the default model without code changes.
- OpenAI, Gemini, and mock providers remain fully supported — flip `LLM_PROVIDER` to pick any.

Closes #100

## Test plan

- [x] `uv run pytest` — 714 passed, 18 skipped, 0 failures
- [x] `uv run ruff check --fix . && uv run ruff format .`
- [x] Added factory tests for the new default model id, custom-model override, and `ANTHROPIC_MODEL` env override
- [ ] With a real `ANTHROPIC_API_KEY`, run one full episode generation end-to-end (`TTS_PROVIDER=mock`) and eyeball script tone quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)